### PR TITLE
chore: add library build with rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Draft.js filters](https://thibaudcolas.github.io/draftjs-filters/) [![npm](https://img.shields.io/npm/v/draftjs-filters.svg?style=flat-square)](https://www.npmjs.com/package/draftjs-filters) [![Build Status](https://travis-ci.org/thibaudcolas/draftjs-filters.svg?branch=master)](https://travis-ci.org/thibaudcolas/draftjs-filters) [![Coverage Status](https://coveralls.io/repos/github/thibaudcolas/draftjs-filters/badge.svg)](https://coveralls.io/github/thibaudcolas/draftjs-filters)
 
-> Filters to sanitise [Draft.js](https://facebook.github.io/draft-js/) content when copy-pasting rich text into the editor, initially made for [Draftail](https://github.com/springload/draftail).
+> Filter [Draft.js](https://facebook.github.io/draft-js/) content when copy-pasting rich text into the editor. Initially made for [Draftail](https://github.com/springload/draftail).
 
 Check out the [online demo](https://thibaudcolas.github.io/draftjs-filters).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3948,6 +3948,12 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+      "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -11053,6 +11059,31 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
+      }
+    },
+    "rollup": {
+      "version": "0.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.53.3.tgz",
+      "integrity": "sha512-MADFV0jpoh1QDB6U0U6YamGihGetxHEYgwTcGsc7map6JFIydPEfGNshK+ozxv1RKeUOQKn1vRb85IAcdjL22Q==",
+      "dev": true
+    },
+    "rollup-plugin-babel": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
+      "integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "1.5.2"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+      "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+      "dev": true,
+      "requires": {
+        "estree-walker": "0.2.1",
+        "minimatch": "3.0.4"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,14 @@
 {
   "name": "draftjs-filters",
   "version": "0.1.0",
-  "description": "",
+  "description": "Filter Draft.js content when copy-pasting rich text into the editor",
   "author": "Thibaud Colas",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "es/index.js",
+  "main": "dist/draftjs-filters.cjs.js",
+  "module": "dist/draftjs-filters.esm.js",
   "keywords": [
-    "draftjs",
-    "draft.js",
-    "draft",
     "draft-js",
+    "draftjs-utils",
     "editor",
     "wysiwyg",
     "rich text",
@@ -43,21 +41,15 @@
       "@commitlint/config-conventional"
     ]
   },
+  "browserslist": "> 1%, IE 11",
   "babel": {
     "presets": [
-      [
-        "env",
-        {
-          "targets": {
-            "browsers": [
-              "> 1%",
-              "IE 11"
-            ]
-          }
-        }
-      ]
+      "env"
     ]
   },
+  "files": [
+    "dist/"
+  ],
   "devDependencies": {
     "@commitlint/cli": "^5.2.8",
     "@commitlint/config-conventional": "^5.2.3",
@@ -71,6 +63,8 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",
+    "rollup": "^0.53.3",
+    "rollup-plugin-babel": "^3.0.3",
     "source-map-explorer": "^1.5.0"
   },
   "dependencies": {},
@@ -80,7 +74,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && source-map-explorer --html build/static/js/main.* > build/source-map-explorer.html",
+    "build": "react-scripts build && source-map-explorer --html build/static/js/main.* > build/source-map-explorer.html && rollup -c",
     "dist": "CI=true npm run build -s",
     "flow": "flow",
     "danger": "danger ci --verbose",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,28 @@
+import babel from "rollup-plugin-babel"
+import pkg from "./package.json"
+
+export default [
+  {
+    input: "src/lib/index.js",
+    external: ["draft-js"],
+    output: [
+      { file: pkg.main, format: "cjs" },
+      { file: pkg.module, format: "es" },
+    ],
+    plugins: [
+      babel({
+        babelrc: false,
+        exclude: ["node_modules/**"],
+        presets: [
+          [
+            "env",
+            {
+              modules: false,
+            },
+          ],
+          "flow",
+        ],
+      }),
+    ],
+  },
+]

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,3 @@
+import { filterEditorState } from "./normalize"
+
+export { filterEditorState }


### PR DESCRIPTION
Adds Rollup to bundle the library code into a single file (one for CommonJS, one for ES modules) for the published package.