### PR TITLE
Publish filters with Flow type annotations

### DIFF
--- a/.githooks/pre-commit.8.test.sh
+++ b/.githooks/pre-commit.8.test.sh
@@ -4,6 +4,6 @@ set -e
 
 if [ -n "$JS_STAGED" ] || [ -n "$SNAPSHOT_STAGED" ];
 then
-    npm run flow -s
+    npx flow
     npm run test:coverage -s
 fi

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,3 +5,48 @@ Thank you for considering to help this project.
 We welcome all support, whether on bug reports, feature requests, code, design, reviews, tests, documentation, and more.
 
 Please note that this project is released with a [Contributor Code of Conduct](/docs/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Development
+
+### Install
+
+> Clone the project on your computer, and install [Node](https://nodejs.org). This project also uses [nvm](https://github.com/creationix/nvm).
+
+```sh
+nvm install
+# Then, install all project dependencies.
+npm install
+# Install the git hooks.
+./.githooks/deploy.sh
+```
+
+### Working on the project
+
+> Everything mentioned in the installation process should already be done.
+
+```sh
+# Make sure you use the right node version.
+nvm use
+# Start the server and the development tools.
+npm run start
+# Runs linting.
+npm run lint
+# Start a Flow server for type errors.
+npx flow
+# Re-formats all of the files in the project (with Prettier).
+npm run format
+# Run tests in a watcher.
+npm run test:watch
+# Run test coverage
+npm run test:coverage
+# Open the coverage report with:
+npm run report:coverage
+# Open the build report with:
+npm run report:build
+# View other available commands with:
+npm run
+```
+
+### Code style
+
+This project uses [Prettier](https://prettier.io/), [ESLint](https://eslint.org/), and [Flow](https://flow.org/). All code should always be checked with those tools.

--- a/README.md
+++ b/README.md
@@ -256,47 +256,6 @@ const editor = <Editor stripPastedStyles={IS_IE11} />
 
 See anything you like in here? Anything missing? We welcome all support, whether on bug reports, feature requests, code, design, reviews, tests, documentation, and more. Please have a look at our [contribution guidelines](.github/CONTRIBUTING.md).
 
-## Development
-
-### Install
-
-> Clone the project on your computer, and install [Node](https://nodejs.org). This project also uses [nvm](https://github.com/creationix/nvm).
-
-```sh
-nvm install
-# Then, install all project dependencies.
-npm install
-# Install the git hooks.
-./.githooks/deploy.sh
-```
-
-### Working on the project
-
-> Everything mentioned in the installation process should already be done.
-
-```sh
-# Make sure you use the right node version.
-nvm use
-# Start the server and the development tools.
-npm run start
-# Runs linting.
-npm run lint
-# Start a Flow server for type errors.
-npx flow
-# Re-formats all of the files in the project (with Prettier).
-npm run format
-# Run tests in a watcher.
-npm run test:watch
-# Run test coverage
-npm run test:coverage
-# Open the coverage report with:
-npm run report:coverage
-# Open the build report with:
-npm run report:build
-# View other available commands with:
-npm run
-```
-
 ## Credits
 
 View the full list of [contributors](https://github.com/springload/draftail/graphs/contributors). [MIT](LICENSE) licensed. Website content available as [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ maxNesting: number,
 whitespacedCharacters: Array<string>,
 ```
 
+### Types
+
+If your project uses [Flow](https://flow.org/), type inference should just work. If you don't use Flow, it won't get in your way either.
+
 ### Advanced usage
 
 `filterEditorState` isn't very flexible. If you want more control over the filtering, simply compose your own filter function with the other single-purpose utilities. The Draft.js filters are published as ES6 modules using [Rollup](https://rollupjs.org/) – module bundlers like Rollup and Webpack will tree shake (remove) the unused functions so you only bundle the code you use.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here are the available options:
 
 ```jsx
 // Whitelist of allowed block types. unstyled and atomic are always included.
-blocks: Array<DraftBlockType>,
+blocks: Array<string>,
 // Whitelist of allowed inline styles.
 styles: Array<string>,
 // Whitelist of allowed entities.
@@ -131,7 +131,7 @@ limitBlockDepth((max: number), (content: ContentState))
 preserveBlockByText(
   (rules: Array<{
     test: string,
-    type: DraftBlockType,
+    type: string,
     depth: number,
   }>),
   (content: ContentState),
@@ -142,7 +142,7 @@ preserveBlockByText(
  * Also sets depth to 0 (for potentially nested list items).
  */
 
-filterBlockTypes((whitelist: Array<DraftBlockType>), (content: ContentState))
+filterBlockTypes((whitelist: Array<string>), (content: ContentState))
 
 /**
  * Removes all styles not present in the whitelist.
@@ -186,7 +186,7 @@ shouldKeepEntityType((whitelist: Array<Object>), (type: string))
  * - The corresponding CharacterMetadata needs to be removed too, and it's 2 instances
  */
 
-shouldRemoveImageEntity((entityType: string), (blockType: DraftBlockType))
+shouldRemoveImageEntity((entityType: string), (blockType: string))
 
 /**
  * Filters entities based on the data they contain.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ npm run start
 # Runs linting.
 npm run lint
 # Start a Flow server for type errors.
-npm run flow
+npx flow
 # Re-formats all of the files in the project (with Prettier).
 npm run format
 # Run tests in a watcher.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,3 +1,5 @@
+// @flow
+// flowlint untyped-import:off
 const { danger, message, warn, fail, schedule } = require("danger")
 
 const libModifiedFiles = danger.git.modified_files.filter(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,6 +2817,16 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-flow-comments": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-comments/-/babel-plugin-transform-flow-comments-6.22.0.tgz",
+      "integrity": "sha1-jZSREy8rSKvQZW+Wwg87vW/BdSk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "start": "react-scripts start",
     "build": "react-scripts build && source-map-explorer --html build/static/js/main.* > build/source-map-explorer.html && rollup -c",
     "dist": "CI=true npm run build -s",
-    "flow": "flow",
     "danger": "danger ci --verbose",
     "semantic-release": "semantic-release",
     "test": "npm run test:coverage -s",
@@ -78,7 +77,7 @@
     "report:package": "npm pack --loglevel notice 2>&1 >/dev/null | sed -e 's/^npm notice //' | tee build/package.txt && rm *.tgz",
     "lint": "prettier --list-different '**/*.{js,css,md,json,yaml,yml}'",
     "format": "prettier --write '**/*.{js,css,md,json,yaml,yml}'",
-    "test:ci": "npm run lint -s && npm run flow -s && npm run dist -s && npm run test:coverage -s -- --outputFile build/test-results.json --json",
+    "test:ci": "npm run lint -s && npm run dist -s && flow && npm run test:coverage -s -- --outputFile build/test-results.json --json",
     "prepublishOnly": "npm run dist -s"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@semantic-release/changelog": "^3.0.0",
     "@semantic-release/exec": "^3.1.3",
     "@semantic-release/git": "^7.0.4",
+    "babel-plugin-transform-flow-comments": "^6.22.0",
     "core-js": "^2.5.7",
     "danger": "^4.0.2",
     "draft-js": "0.10.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,16 @@
 import babel from "rollup-plugin-babel"
 import pkg from "./package.json"
 
+const BANNER = `// @flow
+/*:: import type { ContentState } from "draft-js"*/`
+
 export default [
   {
     input: "src/lib/index.js",
     external: ["draft-js"],
     output: [
-      { file: pkg.main, format: "cjs" },
-      { file: pkg.module, format: "es" },
+      { file: pkg.main, format: "cjs", banner: BANNER },
+      { file: pkg.module, format: "es", banner: BANNER },
     ],
     plugins: [
       babel({
@@ -20,8 +23,8 @@ export default [
               modules: false,
             },
           ],
-          "flow",
         ],
+        plugins: ["transform-flow-comments"],
       }),
     ],
   },

--- a/src/demo/components/FilterableEditor.js
+++ b/src/demo/components/FilterableEditor.js
@@ -7,9 +7,9 @@ import {
   convertToRaw,
   CompositeDecorator,
   AtomicBlockUtils,
-  ContentBlock,
   convertFromRaw,
 } from "draft-js"
+import type { ContentBlock } from "draft-js"
 import type { DraftEntityType } from "draft-js/lib/DraftEntityType.js.flow"
 
 import { filterEditorState } from "../../lib/index"

--- a/src/demo/components/FilterableEditor.js
+++ b/src/demo/components/FilterableEditor.js
@@ -10,7 +10,6 @@ import {
   ContentBlock,
   convertFromRaw,
 } from "draft-js"
-import type { DraftBlockType } from "draft-js/lib/DraftBlockType.js.flow"
 import type { DraftEntityType } from "draft-js/lib/DraftEntityType.js.flow"
 
 import { filterEditorState } from "../../lib/index"
@@ -166,7 +165,7 @@ class FilterableEditor extends Component<Props, State> {
     e.preventDefault()
   }
 
-  toggleBlock(type: DraftBlockType, e: Event) {
+  toggleBlock(type: string, e: Event) {
     const { editorState } = this.state
     this.onChange(RichUtils.toggleBlockType(editorState, type))
 

--- a/src/demo/components/Image.js
+++ b/src/demo/components/Image.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import { ContentBlock, ContentState } from "draft-js"
+import type { ContentBlock, ContentState } from "draft-js"
 
 const Image = ({
   block,

--- a/src/lib/filters/blocks.js
+++ b/src/lib/filters/blocks.js
@@ -1,7 +1,5 @@
 // @flow
 import { ContentState } from "draft-js"
-import type { DraftBlockType } from "draft-js/lib/DraftBlockType.js.flow"
-
 import { UNSTYLED, UNORDERED_LIST_ITEM, ORDERED_LIST_ITEM } from "../constants"
 
 /**
@@ -40,7 +38,7 @@ export const removeInvalidDepthBlocks = (content: ContentState) => {
 export const preserveBlockByText = (
   rules: Array<{
     test: string,
-    type: DraftBlockType,
+    type: string,
     depth: number,
   }>,
   content: ContentState,
@@ -127,7 +125,7 @@ export const limitBlockDepth = (max: number, content: ContentState) => {
  * Also sets depth to 0 (for potentially nested list items).
  */
 export const filterBlockTypes = (
-  whitelist: Array<DraftBlockType>,
+  whitelist: Array<string>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -24,6 +24,8 @@ import {
 } from "./entities"
 import { replaceTextBySpaces } from "./text"
 
+import type { EditorState as EditorStateType } from "draft-js"
+
 type FilterOptions = {
   // Whitelist of allowed block types. unstyled and atomic are always included.
   blocks: Array<string>,
@@ -86,15 +88,16 @@ const PREFIX_RULES = [
  * to enforce it's shaped according to the options.
  */
 export const filterEditorState = (
-  {
+  options: FilterOptions,
+  editorState: EditorStateType,
+) => {
+  const {
     blocks,
     styles,
     entities,
     maxNesting,
     whitespacedCharacters,
-  }: FilterOptions,
-  editorState: EditorState,
-) => {
+  } = options
   const shouldKeepEntityRange = (content, entityKey, block) => {
     const entity = content.getEntity(entityKey)
     const entityData = entity.getData()
@@ -133,7 +136,10 @@ export const filterEditorState = (
   ]
 
   const content = editorState.getCurrentContent()
-  const nextContent = filters.reduce((c, filter) => filter(c), content)
+  const nextContent = filters.reduce(
+    (c, filter: Function) => filter(c),
+    content,
+  )
 
   return nextContent === content
     ? editorState

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -1,6 +1,5 @@
 // @flow
 import { EditorState } from "draft-js"
-import type { DraftBlockType } from "draft-js/lib/DraftBlockType.js.flow"
 
 import { ATOMIC, UNSTYLED } from "../constants"
 import {
@@ -27,7 +26,7 @@ import { replaceTextBySpaces } from "./text"
 
 type FilterOptions = {
   // Whitelist of allowed block types. unstyled and atomic are always included.
-  blocks: Array<DraftBlockType>,
+  blocks: Array<string>,
   // Whitelist of allowed inline styles.
   styles: Array<string>,
   // Whitelist of allowed entities.

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -1,6 +1,5 @@
 // @flow
 import { CharacterMetadata, ContentState, ContentBlock } from "draft-js"
-import type { DraftBlockType } from "draft-js/lib/DraftBlockType.js.flow"
 
 import { ATOMIC, IMAGE } from "../constants"
 
@@ -134,7 +133,7 @@ export const shouldKeepEntityType = (
  */
 export const shouldRemoveImageEntity = (
   entityType: string,
-  blockType: DraftBlockType,
+  blockType: string,
 ) => {
   return entityType === IMAGE && blockType !== ATOMIC
 }

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -1,7 +1,8 @@
 // @flow
-import { CharacterMetadata, ContentState, ContentBlock } from "draft-js"
-
+import { CharacterMetadata, ContentState } from "draft-js"
 import { ATOMIC, IMAGE } from "../constants"
+
+import type { BlockNode } from "draft-js/lib/BlockNode.js.flow"
 
 /**
  * Clones entities in the entityMap, so each range points to its own entity instance.
@@ -77,7 +78,7 @@ export const filterEntityRanges = (
   filterFn: (
     content: ContentState,
     entityKey: string,
-    block: ContentBlock,
+    block: BlockNode,
   ) => boolean,
   content: ContentState,
 ) => {

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -148,12 +148,8 @@ export const shouldKeepEntityByAttribute = (
   data: Object,
 ) => {
   const config = entityTypes.find((t) => t.type === entityType)
-  const whitelist = config ? config.whitelist : null
-
   // If no whitelist is defined, the filter keeps the entity.
-  if (!whitelist) {
-    return true
-  }
+  const whitelist = config && config.whitelist ? config.whitelist : {}
 
   const isValid = Object.keys(whitelist).every((attr) => {
     const check = whitelist[attr]


### PR DESCRIPTION
The Draft.js filters now come with [Flow](https://flow.org/) annotations. For projects that do not use Flow this has no impact. For Flow users, please make sure you correctly type your code so Flow doesn't raise issues because of conflicts with this package's type definitions.

TODO: 

- [x] Documentation for end users
- [x] Documentation for future maintenance
- ~[ ] Danger checks~
- [x] Post-build Flow type check