### PR TITLE
fix(release): make sure released package does not contain archive

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://thibaudcolas.github.io/draftjs-filters/",
   "files": [
-    "dist"
+    "dist/*.js"
   ],
   "browserslist": "> 1%, IE 11",
   "babel": {


### PR DESCRIPTION
Fix for an issue introduced in #17. The test package generation happens in `dist`. We do not want the published package to contain an archive of itself (waste of storage space).