### PR TITLE
Move selection when removing the last block in the paste (#27)

### DIFF
--- a/.githooks/pre-commit.8.test.sh
+++ b/.githooks/pre-commit.8.test.sh
@@ -4,6 +4,5 @@ set -e
 
 if [ -n "$JS_STAGED" ] || [ -n "$SNAPSHOT_STAGED" ];
 then
-    npx flow
-    npm run test:coverage -s
+  npm run test:coverage -s
 fi

--- a/.githooks/pre-commit.9.build.sh
+++ b/.githooks/pre-commit.9.build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+FLOW_STAGED=$(grep -e '.flowconfig$' <<< "$STAGED" || true)
+
+if [ -n "$JS_STAGED" ] || [ -n "$FLOW_STAGED" ];
+then
+  npm run dist
+  npx flow
+fi

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ If your project uses [Flow](https://flow.org/), type inference should just work.
 
 `filterEditorState` isn't very flexible. If you want more control over the filtering, simply compose your own filter function with the other single-purpose utilities. The Draft.js filters are published as ES6 modules using [Rollup](https://rollupjs.org/) – module bundlers like Rollup and Webpack will tree shake (remove) the unused functions so you only bundle the code you use.
 
+If using filters that remove blocks, be sure to use `applyContentWithSelection` to restore the selection where appropriate after filtering.
+
 ```jsx
 /**
  * Creates atomic blocks where they would be required for a block-level entity
@@ -213,6 +215,17 @@ filterEntityData((entityTypes: Array<Object>), (content: ContentState))
  */
 
 replaceTextBySpaces((characters: Array<string>), (content: ContentState))
+
+/**
+ * Applies the new content to the editor state, optionally moving the selection
+ * to be on a valid block (https://github.com/thibaudcolas/draftjs-filters/issues/27).
+ */
+
+applyContentWithSelection = (
+  editorState: EditorStateType,
+  content: ContentState,
+  nextContent: ContentState,
+)
 ```
 
 ### Browser support and polyfills

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,16 @@
 import babel from "rollup-plugin-babel"
 import pkg from "./package.json"
 
-const BANNER = `// @flow
-/*:: import type { ContentState } from "draft-js"*/`
+const BANNER = `// @flow`
+const CJS_BANNER = `${BANNER}
+/*:: import type { ContentState, EditorState } from "draft-js"*/`
 
 export default [
   {
     input: "src/lib/index.js",
     external: ["draft-js"],
     output: [
-      { file: pkg.main, format: "cjs", banner: BANNER },
+      { file: pkg.main, format: "cjs", banner: CJS_BANNER },
       { file: pkg.module, format: "es", banner: BANNER },
     ],
     plugins: [

--- a/src/demo/components/FilterableEditor.js
+++ b/src/demo/components/FilterableEditor.js
@@ -70,7 +70,7 @@ const ENTITIES = [
     label: "📷",
     attributes: ["src"],
     whitelist: {
-      src: "^http|./",
+      src: "^http|\\./",
     },
   },
 ]

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -140,9 +140,5 @@ export const filterEditorState = (
     content,
   )
 
-  if (nextContent === content) {
-    return editorState
-  }
-
   return applyContentWithSelection(editorState, content, nextContent)
 }

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -1,6 +1,4 @@
 // @flow
-import { EditorState } from "draft-js"
-
 import { ATOMIC, UNSTYLED } from "../constants"
 import {
   preserveAtomicBlocks,
@@ -23,6 +21,7 @@ import {
   shouldKeepEntityByAttribute,
 } from "./entities"
 import { replaceTextBySpaces } from "./text"
+import { applyContentWithSelection } from "./selection"
 
 import type { EditorState as EditorStateType } from "draft-js"
 
@@ -141,9 +140,9 @@ export const filterEditorState = (
     content,
   )
 
-  return nextContent === content
-    ? editorState
-    : EditorState.set(editorState, {
-        currentContent: nextContent,
-      })
+  if (nextContent === content) {
+    return editorState
+  }
+
+  return applyContentWithSelection(editorState, content, nextContent)
 }

--- a/src/lib/filters/selection.js
+++ b/src/lib/filters/selection.js
@@ -1,0 +1,51 @@
+// @flow
+import { EditorState } from "draft-js"
+import type { EditorState as EditorStateType } from "draft-js"
+import { ContentState } from "draft-js"
+
+/**
+ * Applies the new content to the editor state, optionally moving the selection
+ * to be on a valid block (https://github.com/thibaudcolas/draftjs-filters/issues/27).
+ */
+export const applyContentWithSelection = (
+  editorState: EditorStateType,
+  content: ContentState,
+  nextContent: ContentState,
+) => {
+  const nextState = EditorState.set(editorState, {
+    currentContent: nextContent,
+  })
+  const selection = editorState.getSelection()
+  const anchorKey = selection.getAnchorKey()
+  const anchorBlock = nextContent.getBlockForKey(anchorKey)
+
+  // We only support moving collapsed selections, which is the only behavior of selections after paste.
+  // And if the anchor block is valid, no need to move the selection.
+  const shouldKeepSelection = !selection.isCollapsed() || !!anchorBlock
+  if (shouldKeepSelection) {
+    return nextState
+  }
+
+  const nextKeys = nextContent.getBlockMap().keySeq()
+
+  // Find the first key whose successor is different in the old content (because a block was removed).
+  // Starting from the end so the selection is preserved towards the last not-removed block in the filtered region.
+  const nextAnchorKey = nextKeys
+    .reverse()
+    .find((k) => content.getKeyAfter(k) !== nextContent.getKeyAfter(k))
+
+  if (nextAnchorKey) {
+    const nextSelectedBlock = nextContent.getBlockForKey(nextAnchorKey)
+    const blockEndOffset = nextSelectedBlock.getText().length
+    const nextSelection = selection.merge({
+      anchorKey: nextAnchorKey,
+      focusKey: nextAnchorKey,
+      anchorOffset: blockEndOffset,
+      focusOffset: blockEndOffset,
+    })
+
+    return EditorState.acceptSelection(nextState, nextSelection)
+  }
+
+  return nextState
+}

--- a/src/lib/filters/selection.js
+++ b/src/lib/filters/selection.js
@@ -44,6 +44,7 @@ export const applyContentWithSelection = (
     .reverse()
     .find((k) => content.getKeyAfter(k) !== nextContent.getKeyAfter(k))
 
+  // If the selection was already misplaced before paste, we do not move it.
   if (nextAnchorKey) {
     const nextSelectedBlock = nextContent.getBlockForKey(nextAnchorKey)
     const blockEndOffset = nextSelectedBlock.getText().length

--- a/src/lib/filters/selection.js
+++ b/src/lib/filters/selection.js
@@ -1,6 +1,5 @@
 // @flow
 import { EditorState } from "draft-js"
-import type { EditorState as EditorStateType } from "draft-js"
 import { ContentState } from "draft-js"
 
 /**
@@ -9,7 +8,7 @@ import { ContentState } from "draft-js"
  * See https://github.com/thibaudcolas/draftjs-filters/issues/27.
  */
 export const applyContentWithSelection = (
-  editorState: EditorStateType,
+  editorState: EditorState,
   content: ContentState,
   nextContent: ContentState,
 ) => {

--- a/src/lib/filters/selection.js
+++ b/src/lib/filters/selection.js
@@ -13,6 +13,11 @@ export const applyContentWithSelection = (
   content: ContentState,
   nextContent: ContentState,
 ) => {
+  // If the content is the same before/after, return the state unaltered.
+  if (nextContent === content) {
+    return editorState
+  }
+
   // If the block map is empty, insert a new unstyled block and put the selection on it.
   if (nextContent.getBlockMap().size === 0) {
     return EditorState.moveFocusToEnd(

--- a/src/lib/filters/selection.test.js
+++ b/src/lib/filters/selection.test.js
@@ -383,5 +383,81 @@ describe("selection", () => {
         focusOffset: 4,
       })
     })
+
+    it("works with consecutive blocks removed", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {
+            "0": {
+              type: "IMAGE",
+              mutability: "IMMUTABLE",
+              data: {
+                src: "file://localhost/clip_image002.png",
+              },
+            },
+          },
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+            {
+              key: "82ioh",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+            {
+              key: "82iof",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+            {
+              key: "35q1h",
+              text: "Test",
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "82iof",
+          focusKey: "82iof",
+          anchorOffset: 1,
+          focusOffset: 1,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "35q1g",
+        anchorOffset: 4,
+        focusKey: "35q1g",
+        focusOffset: 4,
+      })
+    })
   })
 })

--- a/src/lib/filters/selection.test.js
+++ b/src/lib/filters/selection.test.js
@@ -457,5 +457,48 @@ describe("selection", () => {
         focusOffset: 4,
       })
     })
+
+    it("fail-safe if new selection location cannot be determined", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+              depth: 3,
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "abcde",
+          focusKey: "abcde",
+          anchorOffset: 4,
+          focusOffset: 4,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "abcde",
+        anchorOffset: 4,
+        focusKey: "abcde",
+        focusOffset: 4,
+      })
+    })
   })
 })

--- a/src/lib/filters/selection.test.js
+++ b/src/lib/filters/selection.test.js
@@ -31,6 +31,43 @@ describe("selection", () => {
       ]),
     ]
 
+    it("inserts a block if there is none left, with selection on it", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "f8beh",
+              text: "test",
+              depth: 3,
+            },
+          ],
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+      const block = nextState.getCurrentContent().getFirstBlock()
+
+      expect(block.toJS()).toMatchObject({
+        text: "",
+        type: "unstyled",
+        depth: 0,
+      })
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: block.getKey(),
+        anchorOffset: 0,
+        focusKey: block.getKey(),
+        focusOffset: 0,
+      })
+    })
+
     it("does not change selection if valid", () => {
       let editorState = EditorState.createWithContent(
         convertFromRaw({
@@ -131,45 +168,6 @@ describe("selection", () => {
         anchorOffset: 0,
         focusKey: "82iof",
         focusOffset: 1,
-      })
-    })
-
-    it("does not change selection if it cannot be moved elsewhere", () => {
-      let editorState = EditorState.createWithContent(
-        convertFromRaw({
-          entityMap: {},
-          blocks: [
-            {
-              key: "f8beh",
-              text: "test",
-              depth: 3,
-            },
-          ],
-        }),
-      )
-      editorState = EditorState.acceptSelection(
-        editorState,
-        editorState.getSelection().merge({
-          anchorKey: "f8beh",
-          focusKey: "f8beh",
-          anchorOffset: 4,
-          focusOffset: 4,
-        }),
-      )
-
-      const content = editorState.getCurrentContent()
-      const nextContent = filters.reduce((c, filter) => filter(c), content)
-      const nextState = applyContentWithSelection(
-        editorState,
-        content,
-        nextContent,
-      )
-
-      expect(nextState.getSelection().toJS()).toMatchObject({
-        anchorKey: "f8beh",
-        anchorOffset: 4,
-        focusKey: "f8beh",
-        focusOffset: 4,
       })
     })
 

--- a/src/lib/filters/selection.test.js
+++ b/src/lib/filters/selection.test.js
@@ -1,0 +1,387 @@
+import { EditorState, convertFromRaw } from "draft-js"
+
+import {
+  removeInvalidDepthBlocks,
+  preserveAtomicBlocks,
+  resetAtomicBlocks,
+  filterEntityRanges,
+  removeInvalidAtomicBlocks,
+} from "../index"
+import { applyContentWithSelection } from "./selection"
+
+describe("selection", () => {
+  describe("#applyContentWithSelection", () => {
+    const filters = [
+      // 1. clean up blocks.
+      removeInvalidDepthBlocks,
+      // 4. Process atomic blocks before processing entities.
+      preserveAtomicBlocks,
+      resetAtomicBlocks,
+      // 5. Remove entity ranges (and linked entities)
+      filterEntityRanges.bind(null, () => false),
+      // 6. Remove/filter entity-related matters.
+      removeInvalidAtomicBlocks.bind(null, [
+        {
+          type: "IMAGE",
+          attributes: ["src"],
+          whitelist: {
+            src: "^http",
+          },
+        },
+      ]),
+    ]
+
+    it("does not change selection if valid", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "35q1g",
+          focusKey: "35q1g",
+          anchorOffset: 4,
+          focusOffset: 4,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "35q1g",
+        anchorOffset: 4,
+        focusKey: "35q1g",
+        focusOffset: 4,
+      })
+    })
+
+    it("does not change selection if not collapsed", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {
+            "0": {
+              type: "IMAGE",
+              mutability: "IMMUTABLE",
+              data: {
+                src: "file://localhost/clip_image002.png",
+              },
+            },
+          },
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+            {
+              key: "82iof",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "35q1g",
+          focusKey: "82iof",
+          anchorOffset: 0,
+          focusOffset: 1,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "35q1g",
+        anchorOffset: 0,
+        focusKey: "82iof",
+        focusOffset: 1,
+      })
+    })
+
+    it("does not change selection if it cannot be moved elsewhere", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {},
+          blocks: [
+            {
+              key: "f8beh",
+              text: "test",
+              depth: 3,
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "f8beh",
+          focusKey: "f8beh",
+          anchorOffset: 4,
+          focusOffset: 4,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "f8beh",
+        anchorOffset: 4,
+        focusKey: "f8beh",
+        focusOffset: 4,
+      })
+    })
+
+    it("works for the last block", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {
+            "0": {
+              type: "IMAGE",
+              mutability: "IMMUTABLE",
+              data: {
+                src: "file://localhost/clip_image002.png",
+              },
+            },
+          },
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+            {
+              key: "82iof",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "82iof",
+          focusKey: "82iof",
+          anchorOffset: 1,
+          focusOffset: 1,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "35q1g",
+        anchorOffset: 4,
+        focusKey: "35q1g",
+        focusOffset: 4,
+      })
+    })
+
+    it("works on a random block", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {
+            "0": {
+              type: "IMAGE",
+              mutability: "IMMUTABLE",
+              data: {
+                src: "file://localhost/clip_image002.png",
+              },
+            },
+          },
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+            {
+              key: "82iof",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+            {
+              key: "35q1h",
+              text: "Test",
+            },
+
+            {
+              key: "35q1d",
+              text: "Test",
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "82iof",
+          focusKey: "82iof",
+          anchorOffset: 1,
+          focusOffset: 1,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "35q1g",
+        anchorOffset: 4,
+        focusKey: "35q1g",
+        focusOffset: 4,
+      })
+    })
+
+    it("works with multiple blocks removed", () => {
+      let editorState = EditorState.createWithContent(
+        convertFromRaw({
+          entityMap: {
+            "0": {
+              type: "IMAGE",
+              mutability: "IMMUTABLE",
+              data: {
+                src: "file://localhost/clip_image002.png",
+              },
+            },
+          },
+          blocks: [
+            {
+              key: "f8beh",
+              text: "  ",
+            },
+            {
+              key: "82ioh",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+            {
+              key: "35q1g",
+              text: "Test",
+            },
+            {
+              key: "82iof",
+              text: "📷",
+              entityRanges: [
+                {
+                  offset: 0,
+                  length: 1,
+                  key: 0,
+                },
+              ],
+            },
+            {
+              key: "35q1h",
+              text: "Test",
+            },
+            {
+              key: "35q1d",
+              text: "Test",
+            },
+          ],
+        }),
+      )
+      editorState = EditorState.acceptSelection(
+        editorState,
+        editorState.getSelection().merge({
+          anchorKey: "82iof",
+          focusKey: "82iof",
+          anchorOffset: 1,
+          focusOffset: 1,
+        }),
+      )
+
+      const content = editorState.getCurrentContent()
+      const nextContent = filters.reduce((c, filter) => filter(c), content)
+      const nextState = applyContentWithSelection(
+        editorState,
+        content,
+        nextContent,
+      )
+
+      expect(nextState.getSelection().toJS()).toMatchObject({
+        anchorKey: "35q1g",
+        anchorOffset: 4,
+        focusKey: "35q1g",
+        focusOffset: 4,
+      })
+    })
+  })
+})

--- a/src/lib/filters/selection.test.js
+++ b/src/lib/filters/selection.test.js
@@ -31,6 +31,24 @@ describe("selection", () => {
       ]),
     ]
 
+    it("does not alter editorState if content is the same before / after filters", () => {
+      const content = convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: "f8beh",
+            text: "test",
+            depth: 3,
+          },
+        ],
+      })
+      const editorState = EditorState.createWithContent(content)
+
+      expect(applyContentWithSelection(editorState, content, content)).toBe(
+        editorState,
+      )
+    })
+
     it("inserts a block if there is none left, with selection on it", () => {
       let editorState = EditorState.createWithContent(
         convertFromRaw({

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -20,6 +20,7 @@ import {
   filterEntityData,
 } from "./filters/entities"
 import { replaceTextBySpaces } from "./filters/text"
+import { applyContentWithSelection } from "./filters/selection"
 import { filterEditorState } from "./filters/editor"
 
 export {
@@ -38,5 +39,6 @@ export {
   shouldKeepEntityByAttribute,
   filterEntityData,
   replaceTextBySpaces,
+  applyContentWithSelection,
   filterEditorState,
 }

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -13,6 +13,7 @@ import {
   shouldRemoveImageEntity,
   filterEntityData,
   replaceTextBySpaces,
+  applyContentWithSelection,
   filterEditorState,
 } from "./index"
 
@@ -39,5 +40,7 @@ describe(pkg.name, () => {
     expect(shouldRemoveImageEntity).toBeDefined())
   it("filterEntityData", () => expect(filterEntityData).toBeDefined())
   it("replaceTextBySpaces", () => expect(replaceTextBySpaces).toBeDefined())
+  it("applyContentWithSelection", () =>
+    expect(applyContentWithSelection).toBeDefined())
   it("filterEditorState", () => expect(filterEditorState).toBeDefined())
 })


### PR DESCRIPTION
Fixes #27. This adds a new `applyContentWithSelection` function, which moves the selection to the appropriate block when needed. This new method is used in `filterEditorState`, and is also available separately.

TODO:

- [x] Check consequences of empty blocks list, and mitigate