### PR TITLE
Fix case where entity attribute is undefined

### DIFF
--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -160,7 +160,7 @@ export const shouldKeepEntityByAttribute = (
       return check ? hasData : !hasData
     }
 
-    return new RegExp(check).test(data[attr])
+    return new !data.hasOwnProperty(attr) || RegExp(check).test(data[attr])
   })
 
   return isValid

--- a/src/lib/filters/entities.test.js
+++ b/src/lib/filters/entities.test.js
@@ -239,6 +239,7 @@ describe("entities", () => {
               type: "IMAGE",
               whitelist: {
                 src: "^/",
+                href: "^/"
               },
             },
           ],


### PR DESCRIPTION
There was a case I was hitting where if a whitelist value was specified for an attribute and that attribute didn't exist the whole entity would be removed. I don't think this is intended functionality as it essentially makes the whitelist function as not just a registry of allowed values, but also a list of required attributes since `new Regexp('pattern').test(undefined)` will return false.

This pr checks that the attribute actually exists in the data before the check to prevent this case.