### PR TITLE
Use more precise Flow types (#30)

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,7 +14,6 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [lints]
 all=error
-unclear-type=off
 
 [options]
 module.name_mapper='.*\(.css\)' -> 'empty/object'

--- a/README.md
+++ b/README.md
@@ -62,19 +62,21 @@ Here are the available options:
 
 ```jsx
 // Whitelist of allowed block types. unstyled and atomic are always included.
-blocks: Array<string>,
+blocks: $ReadOnlyArray<string>,
 // Whitelist of allowed inline styles.
-styles: Array<string>,
+styles: $ReadOnlyArray<string>,
 // Whitelist of allowed entities.
-entities: Array<{
-    // Entity type, eg. "LINK"
-    type: string,
-    // Allowed attributes. Other attributes will be removed.
-    attributes: Array<string>,
-    // Refine which entities are kept by whitelisting acceptable values with regular expression patterns.
-    whitelist: {
-      [attribute: string]: string,
-    },
+entities: $ReadOnlyArray<{
+  // Entity type, eg. "LINK"
+  type: string,
+  // Allowed attributes. Other attributes will be removed.
+  attributes: $ReadOnlyArray<string>,
+  // Refine which entities are kept by whitelisting acceptable values with regular expression patterns.
+  // It's also possible to use "true" to signify that a field is required to be present,
+  // and "false" for fields required to be absent.
+  whitelist: {
+    [attribute: string]: string | boolean,
+  },
 }>,
 // Maximum amount of depth for lists (0 = no nesting).
 maxNesting: number,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4525,18 +4525,6 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "clipboard": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
-      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -5802,13 +5790,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -9343,16 +9324,6 @@
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -18016,15 +17987,6 @@
         "ansi-styles": "^3.0.0"
       }
     },
-    "prismjs": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.9.0.tgz",
-      "integrity": "sha1-+j4tntw8OIfB8fMJXUHx+bQgDw8=",
-      "dev": true,
-      "requires": {
-        "clipboard": "^1.7.1"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -19673,13 +19635,6 @@
       "requires": {
         "ajv": "^5.0.0"
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -21396,13 +21351,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tiny-emitter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
-      "dev": true,
-      "optional": true
     },
     "tiny-lr": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8384,9 +8384,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.81.0.tgz",
-      "integrity": "sha512-5e8oL3/5rm3G0Eet3yDCne2R/TLo5Fkn+Z5MtHd4wtz+1miLC35Sgo8XvnbTmiZ9epdTZ1q6GLmJWYh7tUlfGg==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.91.0.tgz",
+      "integrity": "sha512-j+L+xNiUYnZZ27MjVI0y2c9474ZHOvdSQq0Tjwh56mEA7tfxYqp5Dcb6aZSwvs3tGMTjCrZow9aUlZf3OoRyDQ==",
       "dev": true
     },
     "flush-write-stream": {
@@ -8567,14 +8567,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8589,20 +8587,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8719,8 +8714,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8732,7 +8726,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8747,7 +8740,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8755,14 +8747,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8781,7 +8771,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8862,8 +8851,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8875,7 +8863,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8997,7 +8984,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "immutable": "~3.7.6",
     "normalize.css": "^7.0.0",
     "prettier": "^1.16.1",
-    "prismjs": "^1.9.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
     "enzyme-to-json": "^3.3.4",
-    "flow-bin": "^0.81.0",
+    "flow-bin": "^0.91.0",
     "immutable": "~3.7.6",
     "normalize.css": "^7.0.0",
     "prettier": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "format": "prettier --write '**/*.{js,css,md,json,yaml,yml,html}'",
     "test:ci": "npm run lint -s && npm run dist -s && flow && npm run test:coverage -s -- --outputFile build/test-results.json --json",
     "prepublishOnly": "npm run dist -s",
-    "build:docs": "documentation readme src/lib/index.js -f md > docs/doc.md --section=API --markdown-toc=false && prettier --write README.md"
+    "build:docs": "documentation readme src/lib/index.js -f md --section=API --markdown-toc=false && prettier --write README.md"
   }
 }

--- a/src/demo/components/FilterableEditor.js
+++ b/src/demo/components/FilterableEditor.js
@@ -118,15 +118,16 @@ class FilterableEditor extends Component<Props, State> {
     this.state = {
       editorState: editorState,
     }
-    ;(this: any).onChange = this.onChange.bind(this)
-    ;(this: any).onTab = this.onTab.bind(this)
-    ;(this: any).toggleStyle = this.toggleStyle.bind(this)
-    ;(this: any).toggleBlock = this.toggleBlock.bind(this)
-    ;(this: any).toggleEntity = this.toggleEntity.bind(this)
-    ;(this: any).blockRenderer = this.blockRenderer.bind(this)
-    ;(this: any).handleKeyCommand = this.handleKeyCommand.bind(this)
+    this.onChange = this.onChange.bind(this)
+    this.onTab = this.onTab.bind(this)
+    this.toggleStyle = this.toggleStyle.bind(this)
+    this.toggleBlock = this.toggleBlock.bind(this)
+    this.toggleEntity = this.toggleEntity.bind(this)
+    this.blockRenderer = this.blockRenderer.bind(this)
+    this.handleKeyCommand = this.handleKeyCommand.bind(this)
   }
 
+  /* :: onChange: (nextState: EditorState) => void; */
   onChange(nextState: EditorState) {
     const { filtered, extended } = this.props
     const { editorState } = this.state
@@ -158,6 +159,7 @@ class FilterableEditor extends Component<Props, State> {
     )
   }
 
+  /* :: toggleStyle: (type: string, e: Event) => void; */
   toggleStyle(type: string, e: Event) {
     const { editorState } = this.state
     this.onChange(RichUtils.toggleInlineStyle(editorState, type))
@@ -165,6 +167,7 @@ class FilterableEditor extends Component<Props, State> {
     e.preventDefault()
   }
 
+  /* :: toggleBlock: (type: string, e: Event) => void; */
   toggleBlock(type: string, e: Event) {
     const { editorState } = this.state
     this.onChange(RichUtils.toggleBlockType(editorState, type))
@@ -172,6 +175,7 @@ class FilterableEditor extends Component<Props, State> {
     e.preventDefault()
   }
 
+  /* :: toggleEntity: (type: DraftEntityType) => void; */
   toggleEntity(type: DraftEntityType) {
     const { editorState } = this.state
     let content = editorState.getCurrentContent()
@@ -194,6 +198,7 @@ class FilterableEditor extends Component<Props, State> {
     }
   }
 
+  /* :: blockRenderer: (block: ContentBlock) => { component: typeof Component, editable: boolean }; */
   blockRenderer(block: ContentBlock) {
     if (block.getType() !== "atomic") {
       return null
@@ -205,6 +210,7 @@ class FilterableEditor extends Component<Props, State> {
     }
   }
 
+  /* :: onTab: (event: SyntheticKeyboardEvent<>) => void; */
   onTab(event: SyntheticKeyboardEvent<>) {
     const { extended } = this.props
     const { editorState } = this.state
@@ -214,6 +220,7 @@ class FilterableEditor extends Component<Props, State> {
     this.onChange(newState)
   }
 
+  /* :: handleKeyCommand: (command: string) => "handled" | "not-handled"; */
   handleKeyCommand(command: string) {
     const { editorState } = this.state
 

--- a/src/demo/components/FilterableEditor.test.js
+++ b/src/demo/components/FilterableEditor.test.js
@@ -4,7 +4,7 @@ import { EditorState, RichUtils, AtomicBlockUtils } from "draft-js"
 
 import FilterableEditor from "./FilterableEditor"
 
-const lib = require("../../lib/index")
+const editor = require("../../lib/filters/editor")
 
 describe("FilterableEditor", () => {
   beforeEach(() => {
@@ -91,8 +91,8 @@ describe("FilterableEditor", () => {
     })
 
     it("#filtered shouldFilterPaste", () => {
-      jest.spyOn(lib, "filterEditorState")
-      lib.filterEditorState.mockImplementation((opts, e) => e)
+      jest.spyOn(editor, "filterEditorState")
+      editor.filterEditorState.mockImplementation((opts, e) => e)
 
       const state = EditorState.createEmpty()
       const fakeState = {
@@ -103,12 +103,12 @@ describe("FilterableEditor", () => {
 
       wrapper.instance().onChange(fakeState)
 
-      expect(lib.filterEditorState).toHaveBeenCalled()
+      expect(editor.filterEditorState).toHaveBeenCalled()
     })
 
     it("#filtered shouldFilterPaste #extended", () => {
-      jest.spyOn(lib, "filterEditorState")
-      lib.filterEditorState.mockImplementation((opts, e) => e)
+      jest.spyOn(editor, "filterEditorState")
+      editor.filterEditorState.mockImplementation((opts, e) => e)
 
       const state = EditorState.createEmpty()
       const fakeState = {
@@ -119,7 +119,7 @@ describe("FilterableEditor", () => {
 
       wrapper.instance().onChange(fakeState)
 
-      expect(lib.filterEditorState).toHaveBeenCalled()
+      expect(editor.filterEditorState).toHaveBeenCalled()
     })
   })
 

--- a/src/demo/components/Highlight.js
+++ b/src/demo/components/Highlight.js
@@ -1,7 +1,5 @@
 // @flow
 import React from "react"
-// flowlint-next-line untyped-import:off
-import Prism from "prismjs"
 
 type Props = {
   value: string,
@@ -27,12 +25,7 @@ const Highlight = ({ value, language }: Props) => (
     >
       Copy
     </button>
-    <code
-      // eslint-disable-next-line springload/react/no-danger
-      dangerouslySetInnerHTML={{
-        __html: Prism.highlight(value, Prism.languages[language]),
-      }}
-    />
+    <code>{value}</code>
   </pre>
 )
 

--- a/src/demo/components/Link.js
+++ b/src/demo/components/Link.js
@@ -1,17 +1,19 @@
 // @flow
 import React from "react"
 import type { Node } from "react"
+import { ContentState } from "draft-js"
+import type { ContentBlock } from "draft-js"
 
 type Props = {
-  contentState: Object,
+  contentState: ContentState,
   entityKey: string,
   children: Node,
 }
 
 export const linkStrategy = (
-  contentBlock: Object,
-  callback: Function,
-  contentState: Object,
+  contentBlock: ContentBlock,
+  callback: (start: number, end: number) => void,
+  contentState: ContentState,
 ) => {
   contentBlock.findEntityRanges((character) => {
     const entityKey = character.getEntity()

--- a/src/demo/components/SentryBoundary.js
+++ b/src/demo/components/SentryBoundary.js
@@ -16,7 +16,7 @@ class SentryBoundary extends Component<Props, State> {
     this.state = { error: null }
   }
 
-  componentDidCatch(error: Error, errorInfo: Object) {
+  componentDidCatch(error: Error, errorInfo: { componentStack: string }) {
     const isRavenAvailable = !!window.Raven
     this.setState({ error })
 

--- a/src/demo/components/__snapshots__/Highlight.test.js.snap
+++ b/src/demo/components/__snapshots__/Highlight.test.js.snap
@@ -20,12 +20,6 @@ exports[`Highlight renders 1`] = `
   >
     Copy
   </button>
-  <code
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "",
-      }
-    }
-  />
+  <code />
 </pre>
 `;

--- a/src/demo/index.js
+++ b/src/demo/index.js
@@ -9,7 +9,6 @@ import "./utils/typography.css"
 import "./utils/layout.css"
 import "./utils/objects.css"
 
-import "prismjs/themes/prism.css"
 import "draft-js/dist/Draft.css"
 
 import "./components/header.css"

--- a/src/lib/filters/atomic.js
+++ b/src/lib/filters/atomic.js
@@ -79,7 +79,7 @@ export const resetAtomicBlocks = (content: ContentState) => {
  * Removes atomic blocks for which the entity isn't whitelisted.
  */
 export const removeInvalidAtomicBlocks = (
-  whitelist: Array<Object>,
+  whitelist: $ReadOnlyArray<{ type: string }>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()

--- a/src/lib/filters/blocks.js
+++ b/src/lib/filters/blocks.js
@@ -36,7 +36,7 @@ export const removeInvalidDepthBlocks = (content: ContentState) => {
  * ends up in the text. Other use cases may not be well covered.
  */
 export const preserveBlockByText = (
-  rules: Array<{
+  rules: $ReadOnlyArray<{
     test: string,
     type: string,
     depth: number,
@@ -125,7 +125,7 @@ export const limitBlockDepth = (max: number, content: ContentState) => {
  * Also sets depth to 0 (for potentially nested list items).
  */
 export const filterBlockTypes = (
-  whitelist: Array<string>,
+  whitelist: $ReadOnlyArray<string>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -23,22 +23,23 @@ import {
 import { replaceTextBySpaces } from "./text"
 import { applyContentWithSelection } from "./selection"
 
+import { ContentState } from "draft-js"
 import type { EditorState as EditorStateType } from "draft-js"
 
 type FilterOptions = {
   // Whitelist of allowed block types. unstyled and atomic are always included.
-  blocks: Array<string>,
+  blocks: $ReadOnlyArray<string>,
   // Whitelist of allowed inline styles.
-  styles: Array<string>,
+  styles: $ReadOnlyArray<string>,
   // Whitelist of allowed entities.
-  entities: Array<{
+  entities: $ReadOnlyArray<{
     // Entity type, eg. "LINK"
     type: string,
     // Allowed attributes. Other attributes will be removed.
-    attributes: Array<string>,
+    attributes: $ReadOnlyArray<string>,
     // Refine which entities are kept by whitelisting acceptable values with regular expression patterns.
     whitelist: {
-      [attribute: string]: string,
+      [attribute: string]: string | boolean,
     },
   }>,
   // Maximum amount of depth for lists (0 = no nesting).
@@ -137,7 +138,7 @@ export const filterEditorState = (
 
   const content = editorState.getCurrentContent()
   const nextContent = filters.reduce(
-    (c, filter: Function) => filter(c),
+    (c, filter: (ContentState) => ContentState) => filter(c),
     content,
   )
 

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -38,6 +38,8 @@ type FilterOptions = {
     // Allowed attributes. Other attributes will be removed.
     attributes: $ReadOnlyArray<string>,
     // Refine which entities are kept by whitelisting acceptable values with regular expression patterns.
+    // It's also possible to use "true" to signify that a field is required to be present,
+    // and "false" for fields required to be absent.
     whitelist: {
       [attribute: string]: string | boolean,
     },

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -122,7 +122,7 @@ export const filterEntityRanges = (
  * Keeps all entity types (images, links, documents, embeds) that are enabled.
  */
 export const shouldKeepEntityType = (
-  whitelist: Array<Object>,
+  whitelist: $ReadOnlyArray<{ type: string }>,
   type: string,
 ) => {
   return whitelist.some((e) => e.type === type)
@@ -143,9 +143,14 @@ export const shouldRemoveImageEntity = (
  * Filters entities based on the data they contain.
  */
 export const shouldKeepEntityByAttribute = (
-  entityTypes: Array<Object>,
+  entityTypes: $ReadOnlyArray<{
+    type: string,
+    whitelist: {
+      [attribute: string]: string | boolean,
+    },
+  }>,
   entityType: string,
-  data: Object,
+  data: {},
 ) => {
   const config = entityTypes.find((t) => t.type === entityType)
   // If no whitelist is defined, the filter keeps the entity.
@@ -172,7 +177,10 @@ export const shouldKeepEntityByAttribute = (
  * of unneeded attributes (width, height, etc).
  */
 export const filterEntityData = (
-  entityTypes: Array<Object>,
+  entityTypes: $ReadOnlyArray<{
+    type: string,
+    attributes: $ReadOnlyArray<string>,
+  }>,
   content: ContentState,
 ) => {
   let newContent = content

--- a/src/lib/filters/styles.js
+++ b/src/lib/filters/styles.js
@@ -5,7 +5,7 @@ import { ContentState, CharacterMetadata } from "draft-js"
  * Removes all styles not present in the whitelist.
  */
 export const filterInlineStyles = (
-  whitelist: Array<string>,
+  whitelist: $ReadOnlyArray<string>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()

--- a/src/lib/filters/text.js
+++ b/src/lib/filters/text.js
@@ -5,7 +5,7 @@ import { ContentState } from "draft-js"
  * Replaces the given characters by their equivalent length of spaces, in all blocks.
  */
 export const replaceTextBySpaces = (
-  characters: Array<string>,
+  characters: $ReadOnlyArray<string>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,17 +1,17 @@
 // @flow
-import {
+export {
   preserveAtomicBlocks,
   resetAtomicBlocks,
   removeInvalidAtomicBlocks,
 } from "./filters/atomic"
-import {
+export {
   removeInvalidDepthBlocks,
   limitBlockDepth,
   preserveBlockByText,
   filterBlockTypes,
 } from "./filters/blocks"
-import { filterInlineStyles } from "./filters/styles"
-import {
+export { filterInlineStyles } from "./filters/styles"
+export {
   cloneEntities,
   filterEntityRanges,
   shouldKeepEntityType,
@@ -19,26 +19,6 @@ import {
   shouldKeepEntityByAttribute,
   filterEntityData,
 } from "./filters/entities"
-import { replaceTextBySpaces } from "./filters/text"
-import { applyContentWithSelection } from "./filters/selection"
-import { filterEditorState } from "./filters/editor"
-
-export {
-  preserveAtomicBlocks,
-  resetAtomicBlocks,
-  removeInvalidAtomicBlocks,
-  removeInvalidDepthBlocks,
-  limitBlockDepth,
-  preserveBlockByText,
-  filterBlockTypes,
-  filterInlineStyles,
-  cloneEntities,
-  filterEntityRanges,
-  shouldKeepEntityType,
-  shouldRemoveImageEntity,
-  shouldKeepEntityByAttribute,
-  filterEntityData,
-  replaceTextBySpaces,
-  applyContentWithSelection,
-  filterEditorState,
-}
+export { replaceTextBySpaces } from "./filters/text"
+export { applyContentWithSelection } from "./filters/selection"
+export { filterEditorState } from "./filters/editor"


### PR DESCRIPTION
Fixes #30.

- Replaced Object type annotations with the required shape (not exact, can have extra attributes for convenience). This might raise type issues, but only if there is indeed a problem in the library usage. See [Flow’s `unclear-type`](https://flow.org/en/docs/linting/rule-reference/#toc-unclear-type) rule for further reference.
- Use [$ReadOnlyArray<T>](https://flow.org/en/docs/types/arrays/#toc-readonlyarray) in place of Array<T>. This is a supertype of Array (so no change required in implementation), which guarantees draftjs-filters does not mutate arrays.