### PR TITLE
Add support for testing with multiple Draft.js versions

### DIFF
--- a/.githooks/pre-commit.8.test.sh
+++ b/.githooks/pre-commit.8.test.sh
@@ -4,5 +4,6 @@ set -e
 
 if [ -n "$JS_STAGED" ] || [ -n "$SNAPSHOT_STAGED" ];
 then
-  npm run test -s
+  DRAFTJS_VERSION=0.10.5 npm run test -s
+  DRAFTJS_VERSION=0.11.2 npm run test -s
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 install:
   - npm ci
+jobs:
+  include:
+    - env: DRAFTJS_VERSION=0.10.5
+    - env: DRAFTJS_VERSION=0.11.2
 script:
   # Test Git hooks in CI, to make sure script upgrades do not break them.
   - npm run prepare

--- a/package-lock.json
+++ b/package-lock.json
@@ -7415,6 +7415,35 @@
         "object-assign": "^4.1.0"
       }
     },
+    "draft-js-11": {
+      "version": "npm:draft-js@0.11.2",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.2.tgz",
+      "integrity": "sha512-JU96XdAigQ4hAmyBMVXps6RQ8+dMhhNI1dDJPMP6OeHuSv+uwDzDg/7lxGQ1PEq+1Q6575jtvxDa7Aw3vy0WHA==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^1.0.0",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -8725,6 +8754,12 @@
           "dev": true
         }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "danger": "9.2.8",
     "documentation": "12.1.4",
     "draft-js": "0.10.5",
+    "draft-js-11": "npm:draft-js@^0.11.2",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.15.1",
     "enzyme-to-json": "3.4.3",

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,3 +5,19 @@ import { createSerializer } from "enzyme-to-json"
 configure({ adapter: new Adapter() })
 
 expect.addSnapshotSerializer(createSerializer({ mode: "deep" }))
+
+jest.mock("draft-js", () => {
+  const packages = {
+    "0.10.5": "draft-js",
+    "0.11.2": "draft-js-11",
+  }
+  const version = process.env.DRAFTJS_VERSION || "0.10.5"
+
+  // Require the original module.
+  const originalModule = jest.requireActual(packages[version])
+
+  return {
+    __esModule: true,
+    ...originalModule,
+  }
+})


### PR DESCRIPTION
This updates the project’s test suite to run both with Draft.js 0.10.5 and 0.11.2. It should make it easy to improve support for new versions and address deprecations without compromising support for 0.10.5 for now.

This uses npm 6.9.0+’s support for module aliases:

```sh
npm install --save-dev draft-js-11@npm:draft-js@0.11.2
```