### PR TITLE
Add `blockTextRules` parameter to filters options. Fix #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ function onChange(nextState) {
 }
 ```
 
-Here are the available options:
+Here are all the available options:
 
 ```jsx
 // Whitelist of allowed block types. unstyled and atomic are always included.
@@ -85,6 +85,17 @@ entities: $ReadOnlyArray<{
 maxNesting: number,
 // Characters to replace with whitespace.
 whitespacedCharacters: Array<string>,
+// Optional: Rules used to automatically convert blocks from one type to another
+// based on the block’s text. Also supports setting the block depth.
+// Defaults to the filters’ built-in block prefix rules.
+blockTextRules?: $ReadOnlyArray<{
+  // A regex as a string, to match against block text, e.g. "^(◦|o |o\t)".
+  test: string,
+  // The type to convert the block to if the test regex matches.
+  type: string,
+  // The depth to set (e.g. for list items with different prefixes per depth).
+  depth: number,
+}>,
 ```
 
 ### Types

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -49,9 +49,20 @@ type FilterOptions = {
   maxNesting: number,
   // Characters to replace with whitespace.
   whitespacedCharacters: Array<string>,
+  // Optional: Rules used to automatically convert blocks from one type to another
+  // based on the block’s text. Also supports setting the block depth.
+  // Defaults to the filters’ built-in block prefix rules.
+  blockTextRules?: $ReadOnlyArray<{
+    // A regex as a string, to match against block text, e.g. "^(◦|o |o\t)".
+    test: string,
+    // The type to convert the block to if the test regex matches.
+    type: string,
+    // The depth to set (e.g. for list items with different prefixes per depth).
+    depth: number,
+  }>,
 }
 
-const PREFIX_RULES = [
+const BLOCK_PREFIX_RULES = [
   {
     // https://regexper.com/#%5E(%C2%B7%20%7C%E2%80%A2%5Ct%7C%E2%80%A2%7C%F0%9F%93%B7%20%7C%5Ct%7C%20%5Ct)
     test: "^(· |•\t|•|📷 |\t| \t)",
@@ -101,6 +112,7 @@ export const filterEditorState = (
     entities,
     maxNesting,
     whitespacedCharacters,
+    blockTextRules = BLOCK_PREFIX_RULES,
   } = options
   const shouldKeepEntityRange = (content, entityKey, block) => {
     const entity = content.getEntity(entityKey)
@@ -119,7 +131,7 @@ export const filterEditorState = (
   const filters = [
     // 1. clean up blocks.
     removeInvalidDepthBlocks,
-    preserveBlockByText.bind(null, PREFIX_RULES),
+    preserveBlockByText.bind(null, blockTextRules),
     limitBlockDepth.bind(null, maxNesting),
     // 2. reset styles and blocks.
     filterInlineStyles.bind(null, styles),

--- a/src/lib/filters/editor.test.js
+++ b/src/lib/filters/editor.test.js
@@ -542,5 +542,24 @@ describe("editor", () => {
         ).toEqual(convertToRaw(filteredState.getCurrentContent()))
       })
     })
+
+    it("#blockTextRules can be overriden (#65)", () => {
+      const content = convertFromRaw({
+        entityMap: { ...preserveBlockByTextEntities },
+        blocks: [...preserveBlockByText],
+      })
+      expect(
+        convertToRaw(
+          filterEditorState(
+            {
+              ...filters,
+              whitespacedCharacters: [],
+              blockTextRules: [],
+            },
+            EditorState.createWithContent(content),
+          ).getCurrentContent(),
+        ),
+      ).toEqual(convertToRaw(content))
+    })
   })
 })


### PR DESCRIPTION
Fixes #65. The `filterEditorState` options now have an optional `blockTextRules` parameter, which allows users to use their own text-based block conversion rules, or entirely disable the conversions by passing an empty array. By default, `blockTextRules` is set to the filters’ built-in prefix rules for list items.