### PR TITLE
Replace whitelist with allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,7 @@ The project has reached a high-enough level of stability to be used in productio
 
 ### Features
 
-- **api:** add ability for whitelist to filter by undefined attribute ([a4af845](https://github.com/thibaudcolas/draftjs-filters/commit/a4af845))
+- **api:** add ability for allowlist to filter by undefined attribute ([a4af845](https://github.com/thibaudcolas/draftjs-filters/commit/a4af845))
 
 # [0.3.0](https://github.com/thibaudcolas/draftjs-filters/compare/v0.2.2...v0.3.0) (2018-01-15)
 
@@ -132,10 +132,10 @@ The project has reached a high-enough level of stability to be used in productio
 - **api:** add enableLineBreak option to filterEditorState ([6c334b3](https://github.com/thibaudcolas/draftjs-filters/commit/6c334b3))
 - **api:** change filterEditorState to separate options & input ([32a4586](https://github.com/thibaudcolas/draftjs-filters/commit/32a4586))
 - **api:** change filterEditorState to take object as param, with keys ([cbac155](https://github.com/thibaudcolas/draftjs-filters/commit/cbac155))
-- **api:** entity data filter keeps all data if no whitelist is defined ([83199dd](https://github.com/thibaudcolas/draftjs-filters/commit/83199dd))
+- **api:** entity data filter keeps all data if no allowlist is defined ([83199dd](https://github.com/thibaudcolas/draftjs-filters/commit/83199dd))
 - **api:** expose all filters to package consumers ([606f8a0](https://github.com/thibaudcolas/draftjs-filters/commit/606f8a0))
 - **api:** expose new whitespaceCharacters method to the API ([9b3057d](https://github.com/thibaudcolas/draftjs-filters/commit/9b3057d))
-- **api:** filter by attr should keep entity if there is no whitelist ([514e093](https://github.com/thibaudcolas/draftjs-filters/commit/514e093))
+- **api:** filter by attr should keep entity if there is no allowlist ([514e093](https://github.com/thibaudcolas/draftjs-filters/commit/514e093))
 - **api:** refactor all filters to work on ContentState ([6c7fbaf](https://github.com/thibaudcolas/draftjs-filters/commit/6c7fbaf))
 - **api:** refactor entity filters to iterator + callback pattern ([1e6d3f2](https://github.com/thibaudcolas/draftjs-filters/commit/1e6d3f2))
 - **api:** remove enableHorizontalRule - use entities instead ([4603a36](https://github.com/thibaudcolas/draftjs-filters/commit/4603a36))
@@ -143,7 +143,7 @@ The project has reached a high-enough level of stability to be used in productio
 - **api:** rename filterEntityAttributes to filterEntityData ([9403ca2](https://github.com/thibaudcolas/draftjs-filters/commit/9403ca2))
 - **api:** replace enableLineBreak with whitespacedCharacters ([a0c7745](https://github.com/thibaudcolas/draftjs-filters/commit/a0c7745))
 - **filters:** add filterEntityAttributes to filterEditorState ([ab0a30e](https://github.com/thibaudcolas/draftjs-filters/commit/ab0a30e))
-- **filters:** add new filterEntityAttributes filter w/ whitelist ([745ba09](https://github.com/thibaudcolas/draftjs-filters/commit/745ba09))
+- **filters:** add new filterEntityAttributes filter w/ allowlist ([745ba09](https://github.com/thibaudcolas/draftjs-filters/commit/745ba09))
 - **filters:** add new whitespaceCharacters method ([6fde9ee](https://github.com/thibaudcolas/draftjs-filters/commit/6fde9ee))
 - **filters:** add removeInvalidDepthBlocks method to API ([5139451](https://github.com/thibaudcolas/draftjs-filters/commit/5139451))
 - **filters:** implement entity filtering by attribute ([ae76945](https://github.com/thibaudcolas/draftjs-filters/commit/ae76945))

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ function onChange(nextState) {
           {
             type: "IMAGE",
             attributes: ["src"],
-            whitelist: {
+            allowlist: {
               src: "^http",
             },
           },
@@ -77,7 +77,7 @@ entities: $ReadOnlyArray<{
   // It's also possible to use "true" to signify that a field is required to be present,
   // and "false" for fields required to be absent.
   // If this is omitted, all entities are kept.
-  whitelist?: {
+  allowlist?: {
     [attribute: string]: string | boolean,
   },
 }>,
@@ -237,7 +237,7 @@ Filters entities based on the data they contain.
 
 ###### Parameters
 
-- `entityTypes` **$ReadOnlyArray&lt;{type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), whitelist: {}?}>**
+- `entityTypes` **$ReadOnlyArray&lt;{type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), allowlist: {}?}>**
 - `entityType` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 - `data` **{}**
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,17 @@ function onChange(nextState) {
 Here are all the available options:
 
 ```jsx
-// Whitelist of allowed block types. unstyled and atomic are always included.
+// List of allowed block types. unstyled and atomic are always included.
 blocks: $ReadOnlyArray<string>,
-// Whitelist of allowed inline styles.
+// List of allowed inline styles.
 styles: $ReadOnlyArray<string>,
-// Whitelist of allowed entities.
+// List of allowed entities.
 entities: $ReadOnlyArray<{
   // Entity type, eg. "LINK"
   type: string,
   // Allowed attributes. Other attributes will be removed. If this is omitted, all attributes are kept.
   attributes?: $ReadOnlyArray<string>,
-  // Refine which entities are kept by whitelisting acceptable values with regular expression patterns.
+  // Refine which entities are kept by matching acceptable values with regular expression patterns.
   // It's also possible to use "true" to signify that a field is required to be present,
   // and "false" for fields required to be absent.
   // If this is omitted, all entities are kept.
@@ -134,7 +134,7 @@ This is how they are stored by Draft.js by default.
 
 ##### removeInvalidAtomicBlocks
 
-Removes atomic blocks for which the entity isn't whitelisted.
+Removes atomic blocks for which the entity isn't allowed.
 
 ###### Parameters
 
@@ -174,7 +174,7 @@ Resets the depth of all the content to at most max.
 
 ##### filterBlockTypes
 
-Converts all block types not present in the whitelist to unstyled.
+Converts all block types not present in the list to unstyled.
 Also sets depth to 0 (for potentially nested list items).
 
 ###### Parameters
@@ -184,7 +184,7 @@ Also sets depth to 0 (for potentially nested list items).
 
 ##### filterInlineStyles
 
-Removes all styles not present in the whitelist.
+Removes all styles not present in the list.
 
 ###### Parameters
 
@@ -243,7 +243,7 @@ Filters entities based on the data they contain.
 
 ##### filterEntityData
 
-Filters data on an entity to only retain what is whitelisted.
+Filters data on an entity to only retain what is allowed.
 This is crucial for IMAGE and LINK, where Draft.js adds a lot
 of unneeded attributes (width, height, etc).
 
@@ -275,8 +275,8 @@ See <https://github.com/thibaudcolas/draftjs-filters/issues/27>.
 
 ##### filterEditorState
 
-Applies whitelist and blacklist operations to the editor content,
-to enforce it's shaped according to the options.
+Applies filtering and preservation operations to the editor content,
+to restrict it to supported patterns.
 Will not alter the editor state if there are no changes to make.
 
 ###### Parameters

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ This is how they are stored by Draft.js by default.
 
 ##### removeInvalidAtomicBlocks
 
-Removes atomic blocks for which the entity isn't allowed.
+Removes atomic blocks for which the entity type isn't allowed.
 
 ###### Parameters
 
-- `whitelist` **$ReadOnlyArray&lt;{type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>**
+- `allowlist` **$ReadOnlyArray&lt;{type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>**
 - `content` **ContentState**
 
 ##### removeInvalidDepthBlocks
@@ -179,7 +179,7 @@ Also sets depth to 0 (for potentially nested list items).
 
 ###### Parameters
 
-- `whitelist` **$ReadOnlyArray&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**
+- `allowlist` **$ReadOnlyArray&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**
 - `content` **ContentState**
 
 ##### filterInlineStyles
@@ -188,7 +188,7 @@ Removes all styles not present in the list.
 
 ###### Parameters
 
-- `whitelist` **$ReadOnlyArray&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**
+- `allowlist` **$ReadOnlyArray&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**
 - `content` **ContentState**
 
 ##### cloneEntities
@@ -218,7 +218,7 @@ Keeps all entity types (images, links, documents, embeds) that are enabled.
 
 ###### Parameters
 
-- `whitelist` **$ReadOnlyArray&lt;{type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>**
+- `allowlist` **$ReadOnlyArray&lt;{type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)}>**
 - `type` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**
 
 ##### shouldRemoveImageEntity

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ blockTextRules?: $ReadOnlyArray<{
 }>,
 ```
 
+### Deprecated
+
+`filterEditorState` (and `shouldKeepEntityByAttribute` described further below) used to support a `whitelist` config option. It has been renamed to `allowlist`, and will be removed altogether in a future release.
+
 ### Types
 
 If your project uses [Flow](https://flow.org/), type inference should just work. If you don't use Flow, it won't get in your way either.

--- a/src/demo/components/FilterableEditor.js
+++ b/src/demo/components/FilterableEditor.js
@@ -62,7 +62,7 @@ const ENTITIES = [
     type: "LINK",
     label: "🔗",
     attributes: ["url"],
-    whitelist: {
+    allowlist: {
       href: "^(http:|https:|undefined$)",
     },
   },
@@ -70,7 +70,7 @@ const ENTITIES = [
     type: "IMAGE",
     label: "📷",
     attributes: ["src"],
-    whitelist: {
+    allowlist: {
       src: "^http|\\./",
     },
   },

--- a/src/lib/filters/atomic.js
+++ b/src/lib/filters/atomic.js
@@ -76,7 +76,7 @@ export const resetAtomicBlocks = (content: ContentState) => {
 }
 
 /**
- * Removes atomic blocks for which the entity isn't whitelisted.
+ * Removes atomic blocks for which the entity type isn't allowed.
  */
 export const removeInvalidAtomicBlocks = (
   whitelist: $ReadOnlyArray<{ type: string }>,

--- a/src/lib/filters/atomic.js
+++ b/src/lib/filters/atomic.js
@@ -79,7 +79,7 @@ export const resetAtomicBlocks = (content: ContentState) => {
  * Removes atomic blocks for which the entity type isn't allowed.
  */
 export const removeInvalidAtomicBlocks = (
-  whitelist: $ReadOnlyArray<{ type: string }>,
+  allowlist: $ReadOnlyArray<{ type: string }>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()
@@ -95,7 +95,7 @@ export const removeInvalidAtomicBlocks = (
     if (entityKey) {
       const type = content.getEntity(entityKey).getType()
 
-      isValid = whitelist.some((t) => t.type === type)
+      isValid = allowlist.some((t) => t.type === type)
     } else {
       isValid = false
     }

--- a/src/lib/filters/blocks.js
+++ b/src/lib/filters/blocks.js
@@ -121,7 +121,7 @@ export const limitBlockDepth = (max: number, content: ContentState) => {
 }
 
 /**
- * Converts all block types not present in the whitelist to unstyled.
+ * Converts all block types not present in the list to unstyled.
  * Also sets depth to 0 (for potentially nested list items).
  */
 export const filterBlockTypes = (

--- a/src/lib/filters/blocks.js
+++ b/src/lib/filters/blocks.js
@@ -125,13 +125,13 @@ export const limitBlockDepth = (max: number, content: ContentState) => {
  * Also sets depth to 0 (for potentially nested list items).
  */
 export const filterBlockTypes = (
-  whitelist: $ReadOnlyArray<string>,
+  allowlist: $ReadOnlyArray<string>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()
 
   const changedBlocks = blockMap
-    .filter((block) => !whitelist.includes(block.getType()))
+    .filter((block) => !allowlist.includes(block.getType()))
     .map((block) =>
       block.merge({
         type: UNSTYLED,

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -41,6 +41,10 @@ type FilterOptions = {
     // It's also possible to use "true" to signify that a field is required to be present,
     // and "false" for fields required to be absent.
     // If this is omitted, all entities are kept.
+    allowlist?: {
+      [attribute: string]: string | boolean,
+    },
+    // Deprecated. Use allowlist instead. Will be removed in a future release.
     whitelist?: {
       [attribute: string]: string | boolean,
     },

--- a/src/lib/filters/editor.js
+++ b/src/lib/filters/editor.js
@@ -27,17 +27,17 @@ import { ContentState } from "draft-js"
 import type { EditorState as EditorStateType } from "draft-js"
 
 type FilterOptions = {
-  // Whitelist of allowed block types. unstyled and atomic are always included.
+  // List of allowed block types. unstyled and atomic are always included.
   blocks: $ReadOnlyArray<string>,
-  // Whitelist of allowed inline styles.
+  // List of allowed inline styles.
   styles: $ReadOnlyArray<string>,
-  // Whitelist of allowed entities.
+  // List of allowed entities.
   entities: $ReadOnlyArray<{
     // Entity type, eg. "LINK"
     type: string,
     // Allowed attributes. Other attributes will be removed. If this is omitted, all attributes are kept.
     attributes?: $ReadOnlyArray<string>,
-    // Refine which entities are kept by whitelisting acceptable values with regular expression patterns.
+    // Refine which entities are kept by matching acceptable values with regular expression patterns.
     // It's also possible to use "true" to signify that a field is required to be present,
     // and "false" for fields required to be absent.
     // If this is omitted, all entities are kept.
@@ -98,8 +98,8 @@ const BLOCK_PREFIX_RULES = [
 ]
 
 /**
- * Applies whitelist and blacklist operations to the editor content,
- * to enforce it's shaped according to the options.
+ * Applies filtering and preservation operations to the editor content,
+ * to restrict it to supported patterns.
  * Will not alter the editor state if there are no changes to make.
  */
 export const filterEditorState = (

--- a/src/lib/filters/editor.test.js
+++ b/src/lib/filters/editor.test.js
@@ -457,14 +457,14 @@ const filters = {
     {
       type: "IMAGE",
       attributes: ["src"],
-      whitelist: {
+      allowlist: {
         src: "^/",
       },
     },
     {
       type: "LINK",
       attributes: ["url"],
-      whitelist: {},
+      allowlist: {},
     },
   ],
   maxNesting: 1,

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -145,6 +145,10 @@ export const shouldRemoveImageEntity = (
 export const shouldKeepEntityByAttribute = (
   entityTypes: $ReadOnlyArray<{
     type: string,
+    allowlist?: {
+      [attribute: string]: string | boolean,
+    },
+    // Deprecated. Use allowlist instead. Will be removed in a future release.
     whitelist?: {
       [attribute: string]: string | boolean,
     },
@@ -153,11 +157,16 @@ export const shouldKeepEntityByAttribute = (
   data: {},
 ) => {
   const config = entityTypes.find((t) => t.type === entityType)
-  // If no whitelist is defined, the filter keeps the entity.
-  const whitelist = config && config.whitelist ? config.whitelist : {}
+  // If no allowlist is defined, the filter keeps the entity.
+  const allowlist =
+    config && config.allowlist
+      ? config.allowlist
+      : config && config.whitelist
+      ? config.whitelist
+      : {}
 
-  const isValid = Object.keys(whitelist).every((attr) => {
-    const check = whitelist[attr]
+  const isValid = Object.keys(allowlist).every((attr) => {
+    const check = allowlist[attr]
 
     if (typeof check === "boolean") {
       const hasData = data.hasOwnProperty(attr)

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -172,7 +172,7 @@ export const shouldKeepEntityByAttribute = (
 }
 
 /**
- * Filters data on an entity to only retain what is whitelisted.
+ * Filters data on an entity to only retain what is allowed.
  * This is crucial for IMAGE and LINK, where Draft.js adds a lot
  * of unneeded attributes (width, height, etc).
  */

--- a/src/lib/filters/entities.js
+++ b/src/lib/filters/entities.js
@@ -122,10 +122,10 @@ export const filterEntityRanges = (
  * Keeps all entity types (images, links, documents, embeds) that are enabled.
  */
 export const shouldKeepEntityType = (
-  whitelist: $ReadOnlyArray<{ type: string }>,
+  allowlist: $ReadOnlyArray<{ type: string }>,
   type: string,
 ) => {
-  return whitelist.some((e) => e.type === type)
+  return allowlist.some((e) => e.type === type)
 }
 
 /**
@@ -200,14 +200,14 @@ export const filterEntityData = (
     const entity = entities[key]
     const data = entity.getData()
     const config = entityTypes.find((t) => t.type === entity.getType())
-    const whitelist = config ? config.attributes : null
+    const allowlist = config ? config.attributes : null
 
-    // If no whitelist is defined, keep all of the data.
-    if (!whitelist) {
+    // If no allowlist is defined, keep all of the data.
+    if (!allowlist) {
       return data
     }
 
-    const newData = whitelist.reduce((attrs, attr) => {
+    const newData = allowlist.reduce((attrs, attr) => {
       // We do not want to include undefined values if there is no data.
       if (data.hasOwnProperty(attr)) {
         attrs[attr] = data[attr]

--- a/src/lib/filters/entities.test.js
+++ b/src/lib/filters/entities.test.js
@@ -421,7 +421,7 @@ describe("entities", () => {
         ).toBe(true)
       })
 
-      it("no whitelist", () => {
+      it("no allowlist", () => {
         expect(
           shouldKeepEntityByAttribute(
             [
@@ -595,7 +595,7 @@ describe("entities", () => {
         })
       })
 
-      it("no whitelist", () => {
+      it("no allowlist", () => {
         let content = convertFromRaw({
           entityMap: {
             4: {

--- a/src/lib/filters/entities.test.js
+++ b/src/lib/filters/entities.test.js
@@ -237,7 +237,7 @@ describe("entities", () => {
           [
             {
               type: "IMAGE",
-              whitelist: {
+              allowlist: {
                 src: "^/",
               },
             },
@@ -256,7 +256,7 @@ describe("entities", () => {
           [
             {
               type: "IMAGE",
-              whitelist: {
+              allowlist: {
                 src: "^/",
               },
             },
@@ -275,7 +275,7 @@ describe("entities", () => {
           [
             {
               type: "LINK",
-              whitelist: {
+              allowlist: {
                 href: "^(http:|https:|undefined$)",
               },
             },
@@ -295,7 +295,7 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
-                whitelist: {
+                allowlist: {
                   href: "^(http:|https:|undefined$)",
                   target: "_blank",
                 },
@@ -316,7 +316,7 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
-                whitelist: {
+                allowlist: {
                   href: "^(http:|https:|undefined$)",
                   target: "_blank",
                 },
@@ -339,7 +339,7 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
-                whitelist: {
+                allowlist: {
                   id: true,
                 },
               },
@@ -356,7 +356,7 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
-                whitelist: {
+                allowlist: {
                   id: true,
                 },
               },
@@ -375,7 +375,7 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
-                whitelist: {
+                allowlist: {
                   id: false,
                 },
               },
@@ -392,7 +392,7 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
-                whitelist: {
+                allowlist: {
                   id: false,
                 },
               },
@@ -427,6 +427,32 @@ describe("entities", () => {
             [
               {
                 type: "LINK",
+              },
+            ],
+            "LINK",
+            {},
+          ),
+        ).toBe(true)
+      })
+
+      it("deprecated whitelist", () => {
+        expect(
+          shouldKeepEntityByAttribute(
+            [{ type: "LINK", whitelist: { id: true } }],
+            "LINK",
+            {},
+          ),
+        ).toBe(false)
+      })
+
+      it("invalid – both allowlist and whitelist", () => {
+        expect(
+          shouldKeepEntityByAttribute(
+            [
+              {
+                type: "LINK",
+                allowlist: { id: false },
+                whitelist: { id: true },
               },
             ],
             "LINK",

--- a/src/lib/filters/selection.test.js
+++ b/src/lib/filters/selection.test.js
@@ -24,7 +24,7 @@ describe("selection", () => {
         {
           type: "IMAGE",
           attributes: ["src"],
-          whitelist: {
+          allowlist: {
             src: "^http",
           },
         },

--- a/src/lib/filters/styles.js
+++ b/src/lib/filters/styles.js
@@ -2,7 +2,7 @@
 import { ContentState, CharacterMetadata } from "draft-js"
 
 /**
- * Removes all styles not present in the whitelist.
+ * Removes all styles not present in the list.
  */
 export const filterInlineStyles = (
   whitelist: $ReadOnlyArray<string>,

--- a/src/lib/filters/styles.js
+++ b/src/lib/filters/styles.js
@@ -5,7 +5,7 @@ import { ContentState, CharacterMetadata } from "draft-js"
  * Removes all styles not present in the list.
  */
 export const filterInlineStyles = (
-  whitelist: $ReadOnlyArray<string>,
+  allowlist: $ReadOnlyArray<string>,
   content: ContentState,
 ) => {
   const blockMap = content.getBlockMap()
@@ -18,7 +18,7 @@ export const filterInlineStyles = (
 
       char
         .getStyle()
-        .filter((type) => !whitelist.includes(type))
+        .filter((type) => !allowlist.includes(type))
         .forEach((type) => {
           altered = true
           newChar = CharacterMetadata.removeStyle(newChar, type)

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -19,14 +19,14 @@ export const config = {
     {
       type: "LINK",
       attributes: ["url"],
-      whitelist: {
+      allowlist: {
         href: "^(http:|https:|undefined$)",
       },
     },
     {
       type: "IMAGE",
       attributes: ["src"],
-      whitelist: {
+      allowlist: {
         src: "^http",
       },
     },


### PR DESCRIPTION
Most of it is documentation, but there is one part of the API that uses `whitelist`. This is deprecated only, still supported, and will only be fully removed in a future release.